### PR TITLE
Added getGasEIP1559, feeHistory methods and Upgrade EtherAmount

### DIFF
--- a/lib/src/core/amount.dart
+++ b/lib/src/core/amount.dart
@@ -17,7 +17,39 @@ enum EtherUnit {
   ///finney, 10^15 wei or 1 mEther
   finney,
 
-  ether
+  ///1 Ether
+  ether,
+
+  ///in decimals values
+  decimals1,
+  decimals2,
+  decimals3,
+  decimals4,
+  decimals5,
+  decimals6,
+  decimals7,
+  decimals8,
+  decimals9,
+  decimals10,
+  decimals11,
+  decimals12,
+  decimals13,
+  decimals14,
+  decimals15,
+  decimals16,
+  decimals17,
+  decimals18,
+  decimals19,
+  decimals20,
+  decimals21,
+  decimals22,
+  decimals23,
+  decimals24,
+  decimals25,
+  decimals26,
+  decimals27,
+  decimals28,
+  decimals29,
 }
 
 /// Utility class to easily convert amounts of Ether into different units of
@@ -28,21 +60,15 @@ class EtherAmount {
   EtherAmount.zero() : this.inWei(BigInt.zero);
 
   /// Constructs an amount of Ether by a unit and its amount. [amount] can
-  /// either be a base10 string, an int, or a BigInt.
+  /// either be a base10 string, an int, double or a BigInt.
   factory EtherAmount.fromUnitAndValue(EtherUnit unit, dynamic amount) {
-    BigInt parsedAmount;
-
-    if (amount is BigInt) {
-      parsedAmount = amount;
-    } else if (amount is int) {
-      parsedAmount = BigInt.from(amount);
-    } else if (amount is String) {
-      parsedAmount = BigInt.parse(amount);
-    } else {
-      throw ArgumentError('Invalid type, must be BigInt, string or int');
+    if (amount is String) {
+      amount = double.parse(amount);
     }
 
-    return EtherAmount.inWei(parsedAmount * _factors[unit]!);
+    return EtherAmount.inWei(
+      BigInt.from(amount.toDouble() * _factors[unit]!.toDouble()),
+    );
   }
 
   /// Gets the value of this amount in the specified unit as a whole number.
@@ -52,6 +78,10 @@ class EtherAmount {
   /// using a BigInt storing the amount in wei.
   BigInt getValueInUnitBI(EtherUnit unit) => _value ~/ _factors[unit]!;
 
+  /// Gets the value of this amount in the specified decimals int as a whole number.
+  BigInt getValueInDecimalsBI(int decimals) =>
+      getValueInUnitBI(getUintDecimals(decimals));
+
   static final Map<EtherUnit, BigInt> _factors = {
     EtherUnit.wei: BigInt.one,
     EtherUnit.kwei: BigInt.from(10).pow(3),
@@ -59,7 +89,36 @@ class EtherAmount {
     EtherUnit.gwei: BigInt.from(10).pow(9),
     EtherUnit.szabo: BigInt.from(10).pow(12),
     EtherUnit.finney: BigInt.from(10).pow(15),
-    EtherUnit.ether: BigInt.from(10).pow(18)
+    EtherUnit.ether: BigInt.from(10).pow(18),
+    EtherUnit.decimals1: BigInt.from(10).pow(1),
+    EtherUnit.decimals2: BigInt.from(10).pow(2),
+    EtherUnit.decimals3: BigInt.from(10).pow(3),
+    EtherUnit.decimals4: BigInt.from(10).pow(4),
+    EtherUnit.decimals5: BigInt.from(10).pow(5),
+    EtherUnit.decimals6: BigInt.from(10).pow(6),
+    EtherUnit.decimals7: BigInt.from(10).pow(7),
+    EtherUnit.decimals8: BigInt.from(10).pow(8),
+    EtherUnit.decimals9: BigInt.from(10).pow(9),
+    EtherUnit.decimals10: BigInt.from(10).pow(10),
+    EtherUnit.decimals11: BigInt.from(10).pow(11),
+    EtherUnit.decimals12: BigInt.from(10).pow(12),
+    EtherUnit.decimals13: BigInt.from(10).pow(13),
+    EtherUnit.decimals14: BigInt.from(10).pow(14),
+    EtherUnit.decimals15: BigInt.from(10).pow(15),
+    EtherUnit.decimals16: BigInt.from(10).pow(16),
+    EtherUnit.decimals17: BigInt.from(10).pow(17),
+    EtherUnit.decimals18: BigInt.from(10).pow(18),
+    EtherUnit.decimals19: BigInt.from(10).pow(19),
+    EtherUnit.decimals20: BigInt.from(10).pow(20),
+    EtherUnit.decimals21: BigInt.from(10).pow(21),
+    EtherUnit.decimals22: BigInt.from(10).pow(22),
+    EtherUnit.decimals23: BigInt.from(10).pow(23),
+    EtherUnit.decimals24: BigInt.from(10).pow(24),
+    EtherUnit.decimals25: BigInt.from(10).pow(25),
+    EtherUnit.decimals26: BigInt.from(10).pow(26),
+    EtherUnit.decimals27: BigInt.from(10).pow(27),
+    EtherUnit.decimals28: BigInt.from(10).pow(28),
+    EtherUnit.decimals29: BigInt.from(10).pow(29),
   };
 
   final BigInt _value;
@@ -78,6 +137,19 @@ class EtherAmount {
     final remainder = _value.remainder(factor);
 
     return value.toInt() + (remainder.toInt() / factor.toInt());
+  }
+
+  /// Gets the value of this amount in the specified decimals int.
+  double getValueInDecimals(int decimals) =>
+      getValueInUnit(getUintDecimals(decimals));
+
+  /// Gets Uint of decimals by decimals int
+  static EtherUnit getUintDecimals(int decimals) {
+    for (EtherUnit uint in EtherUnit.values) {
+      if (uint.name == 'decimals$decimals') return uint;
+    }
+
+    throw Exception('invalid $decimals value of decimals must be 1 to 29');
   }
 
   @override

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -448,6 +448,56 @@ class Web3Client {
     return hexToInt(amountHex);
   }
 
+  Future<Map<String, EIP1559Information>> getGasInEIP1559() async {
+    List<String> rates = ['slow', 'medium', 'fast'];
+    int historicalBlocks = 10;
+    List<Map<String, dynamic>> history = [];
+    Map<String, EIP1559Information> result = {};
+
+    Map<String, dynamic> feeHistory = await getFeeHistory(
+      historicalBlocks,
+      atBlock: BlockNum.pending(),
+      rewardPercentiles: [25, 50, 75],
+    );
+
+    for (int index = 0; index < historicalBlocks; index++) {
+      history.add({
+        'blockNumber': feeHistory['oldestBlock'] + BigInt.from(index),
+        'baseFeePerGas': feeHistory['baseFeePerGas'][index],
+        'gasUsedRatio': feeHistory['gasUsedRatio'][index],
+        'priorityFeePerGas': feeHistory['reward'][index],
+      });
+    }
+
+    BlockInformation latestBlock = await getBlockInformation(
+      blockNumber: BlockNum.pending().toString(),
+    );
+    BigInt baseFee = latestBlock.baseFeePerGas!.getInWei;
+
+    for (int index = 0; index < rates.length; index++) {
+      List<BigInt> allPriorityFee = history.map<BigInt>((e) {
+        return e['priorityFeePerGas'][index];
+      }).toList();
+      BigInt priorityFee = allPriorityFee.max;
+      BigInt estimatedGas = BigInt.from(
+        0.9 * baseFee.toDouble() + priorityFee.toDouble(),
+      );
+      BigInt maxFee = BigInt.from(1.5 * estimatedGas.toDouble());
+
+      if (priorityFee >= maxFee || priorityFee <= BigInt.zero) {
+        throw Exception('Max fee must exceed the priority fee');
+      }
+
+      result[rates[index]] = EIP1559Information(
+        maxPriorityFeePerGas: EtherAmount.inWei(priorityFee),
+        maxFeePerGas: EtherAmount.inWei(maxFee),
+        estimatedGas: estimatedGas,
+      );
+    }
+
+    return result;
+  }
+
   /// Sends a raw method call to a smart contract.
   ///
   /// The connected node must be able to calculate the result locally, which

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -284,6 +284,35 @@ class Web3Client {
     });
   }
 
+  /// Returns fee history of some blocks
+  Future<Map<String, dynamic>> getFeeHistory(
+    int blockCount, {
+    BlockNum? atBlock,
+    List<double>? rewardPercentiles,
+  }) {
+    final blockParam = _getBlockParam(atBlock);
+
+    return _makeRPCCall<Map<String, dynamic>>(
+      'eth_feeHistory',
+      [blockCount, blockParam, rewardPercentiles],
+    ).then((history) {
+      return history.map((key, dynamic value) {
+        if (key == 'baseFeePerGas') {
+          value = value.map((dynamic e) => hexToInt(e)).toList();
+        } else if (key == 'reward') {
+          value = value.map(
+            (dynamic eList) {
+              return eList.map((dynamic e) => hexToInt(e)).toList();
+            },
+          ).toList();
+        } else if (key == 'oldestBlock') {
+          value = hexToInt(value);
+        }
+        return MapEntry(key, value);
+      });
+    });
+  }
+
   /// Signs the given transaction using the keys supplied in the [cred]
   /// object to upload it to the client so that it can be executed.
   ///

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -298,15 +298,15 @@ class Web3Client {
     ).then((history) {
       return history.map((key, dynamic value) {
         if (key == 'baseFeePerGas') {
-          value = value.map((dynamic e) => hexToInt(e)).toList();
+          value = value.map((dynamic e) => hexToInt(e.toString())).toList();
         } else if (key == 'reward') {
           value = value.map(
             (dynamic eList) {
-              return eList.map((dynamic e) => hexToInt(e)).toList();
+              return eList.map((dynamic e) => hexToInt(e.toString())).toList();
             },
           ).toList();
         } else if (key == 'oldestBlock') {
-          value = hexToInt(value);
+          value = hexToInt(value.toString());
         }
         return MapEntry(key, value);
       });
@@ -449,14 +449,14 @@ class Web3Client {
   }
 
   Future<Map<String, EIP1559Information>> getGasInEIP1559() async {
-    List<String> rates = ['slow', 'medium', 'fast'];
-    int historicalBlocks = 10;
-    List<Map<String, dynamic>> history = [];
-    Map<String, EIP1559Information> result = {};
+    final List<String> rates = ['slow', 'medium', 'fast'];
+    const int historicalBlocks = 10;
+    final List<Map<String, dynamic>> history = [];
+    final Map<String, EIP1559Information> result = {};
 
-    Map<String, dynamic> feeHistory = await getFeeHistory(
+    final Map<String, dynamic> feeHistory = await getFeeHistory(
       historicalBlocks,
-      atBlock: BlockNum.pending(),
+      atBlock: const BlockNum.pending(),
       rewardPercentiles: [25, 50, 75],
     );
 
@@ -469,20 +469,20 @@ class Web3Client {
       });
     }
 
-    BlockInformation latestBlock = await getBlockInformation(
-      blockNumber: BlockNum.pending().toString(),
+    final BlockInformation latestBlock = await getBlockInformation(
+      blockNumber: const BlockNum.pending().toString(),
     );
-    BigInt baseFee = latestBlock.baseFeePerGas!.getInWei;
+    final BigInt baseFee = latestBlock.baseFeePerGas!.getInWei;
 
     for (int index = 0; index < rates.length; index++) {
-      List<BigInt> allPriorityFee = history.map<BigInt>((e) {
-        return e['priorityFeePerGas'][index];
+      final List<BigInt> allPriorityFee = history.map<BigInt>((e) {
+        return e['priorityFeePerGas'][index] as BigInt;
       }).toList();
-      BigInt priorityFee = allPriorityFee.max;
-      BigInt estimatedGas = BigInt.from(
+      final BigInt priorityFee = allPriorityFee.max;
+      final BigInt estimatedGas = BigInt.from(
         0.9 * baseFee.toDouble() + priorityFee.toDouble(),
       );
-      BigInt maxFee = BigInt.from(1.5 * estimatedGas.toDouble());
+      final BigInt maxFee = BigInt.from(1.5 * estimatedGas.toDouble());
 
       if (priorityFee >= maxFee || priorityFee <= BigInt.zero) {
         throw Exception('Max fee must exceed the priority fee');

--- a/lib/src/core/eip1559_information.dart
+++ b/lib/src/core/eip1559_information.dart
@@ -1,0 +1,27 @@
+import 'package:web3dart/src/core/amount.dart';
+
+class EIP1559Information {
+  EIP1559Information({
+    required this.maxPriorityFeePerGas,
+    required this.maxFeePerGas,
+    required this.estimatedGas,
+  });
+
+  factory EIP1559Information.fromJson(Map<String, double> json) =>
+      EIP1559Information(
+        maxPriorityFeePerGas:
+            EtherAmount.inWei(BigInt.from(json['maxPriorityFeePerGas']!)),
+        maxFeePerGas: EtherAmount.inWei(BigInt.from(json['maxFeePerGas']!)),
+        estimatedGas: BigInt.from(json['estimatedGas']!),
+      );
+
+  Map<String, double> toJson() => {
+        'maxPriorityFeePerGas': maxPriorityFeePerGas.getInWei.toDouble(),
+        'maxFeePerGas': maxFeePerGas.getInWei.toDouble(),
+        'estimatedGas': estimatedGas.toDouble(),
+      };
+
+  final EtherAmount maxPriorityFeePerGas;
+  final EtherAmount maxFeePerGas;
+  final BigInt estimatedGas;
+}

--- a/lib/src/core/eip1559_information.dart
+++ b/lib/src/core/eip1559_information.dart
@@ -7,18 +7,18 @@ class EIP1559Information {
     required this.estimatedGas,
   });
 
-  factory EIP1559Information.fromJson(Map<String, double> json) =>
+  factory EIP1559Information.fromJson(Map<String, String> json) =>
       EIP1559Information(
         maxPriorityFeePerGas:
-            EtherAmount.inWei(BigInt.from(json['maxPriorityFeePerGas']!)),
-        maxFeePerGas: EtherAmount.inWei(BigInt.from(json['maxFeePerGas']!)),
-        estimatedGas: BigInt.from(json['estimatedGas']!),
+            EtherAmount.inWei(BigInt.parse(json['maxPriorityFeePerGas']!)),
+        maxFeePerGas: EtherAmount.inWei(BigInt.parse(json['maxFeePerGas']!)),
+        estimatedGas: BigInt.parse(json['estimatedGas']!),
       );
 
-  Map<String, double> toJson() => {
-        'maxPriorityFeePerGas': maxPriorityFeePerGas.getInWei.toDouble(),
-        'maxFeePerGas': maxFeePerGas.getInWei.toDouble(),
-        'estimatedGas': estimatedGas.toDouble(),
+  Map<String, String> toJson() => {
+        'maxPriorityFeePerGas': maxPriorityFeePerGas.getInWei.toString(),
+        'maxFeePerGas': maxFeePerGas.getInWei.toString(),
+        'estimatedGas': estimatedGas.toString(),
       };
 
   final EtherAmount maxPriorityFeePerGas;

--- a/lib/web3dart.dart
+++ b/lib/web3dart.dart
@@ -20,6 +20,7 @@ import 'src/core/block_number.dart';
 import 'src/core/sync_information.dart';
 import 'src/utils/rlp.dart' as rlp;
 import 'src/utils/typed_data.dart';
+import 'src/core/eip1559_information.dart';
 
 export 'contracts.dart';
 export 'credentials.dart';
@@ -28,6 +29,7 @@ export 'src/core/amount.dart';
 export 'src/core/block_information.dart';
 export 'src/core/block_number.dart';
 export 'src/core/sync_information.dart';
+export 'src/core/eip1559_information.dart';
 
 part 'src/core/client.dart';
 part 'src/core/filters.dart';


### PR DESCRIPTION
Get maxFeePerGas and maxPriorityFeePerGas using getGasInEIP1559 method
```dart
Web3Client web3 = Web3Client(network.rpc, httpClient);

Map<String, EIP1559Information> gasEIP = await web3.getGasInEIP1559();
// result: {'slow': EIP1559Information, 'medium': EIP1559Information, 'fast': EIP1559Information}

// Choose the speed rate you want, for example (medium)
EIP1559Information gasEIPInfo = gasEIP['medium']!;

// Finally, set the gas fee of your choice
Transaction tx = Transaction(
  maxPriorityFeePerGas: gasEIPInfo.maxPriorityFeePerGas,
  maxFeePerGas: gasEIPInfo.maxFeePerGas,
);
```

Get fee history from some blocks
```dart
// Count of blocks
int historicalBlocks = 10;

Map<String, dynamic> feeHistory = await web3.getFeeHistory(
  historicalBlocks,
  atBlock: BlockNum.pending(),
  rewardPercentiles: [25, 50, 75], // percentage of fill
);
```

EtherAmount able to get value by decimals ( To handle different decimals of tokens )
EtherAmount acceptable datatypes of string, int, double or BigInt
```dart
int tokenDecimals = 9;

EtherAmount amount = EtherAmount.fromUnitAndValue(
  EtherAmount.getUintDecimals(tokenDecimals),
  100.65658,
);

// Get value in decimals
amount.getValueInDecimals(tokenDecimals)
// result: 100.65658
```