### PR TITLE
JSON-RPC: fix type-error to get useful RPCErrors

### DIFF
--- a/lib/json_rpc.dart
+++ b/lib/json_rpc.dart
@@ -37,7 +37,6 @@ class JsonRPC {
     );
 
     final data = json.decode(response.body) as Map<String, dynamic>;
-    final id = data['id'] as int;
 
     if (data.containsKey('error')) {
       final error = data['error'];
@@ -49,6 +48,7 @@ class JsonRPC {
       throw RPCError(code, message, errorData);
     }
 
+    final id = data['id'] as int;
     final result = data['result'];
     return RPCResponse(id, result);
   }


### PR DESCRIPTION
Dear maintainers,

I am using web3dart ever since I switched from React to Flutter, and it is working great so far.
However, I am frequently facing the following type-error if a JSON-RPC gives me an error-response:

`type 'Null' is not a subtype of type 'int' in type cast`

The problem is that this type-error hides the real error-message that happened in JSON-RPC.
This PR fixes the problem by throwing a useful RPCError as intended by the already existing error-handling in web3dart.