### PR TITLE
add nullable topics in filters

### DIFF
--- a/lib/src/core/filters.dart
+++ b/lib/src/core/filters.dart
@@ -114,7 +114,7 @@ class FilterOptions {
   /// All further topics are the encoded values of the indexed parameters of the
   /// event. See https://solidity.readthedocs.io/en/develop/contracts.html#events
   /// for a detailed description.
-  final List<List<String>>? topics;
+  final List<List<String?>>? topics;
 }
 
 /// A log event emitted in a transaction.
@@ -149,7 +149,7 @@ class FilterEvent {
             : null,
         address = EthereumAddress.fromHex(log['address'] as String),
         data = log['data'] as String?,
-        topics = (log['topics'] as List?)?.cast<String>();
+        topics = (log['topics'] as List?)?.cast<String?>();
 
   /// Whether the log was removed, due to a chain reorganization. False if it's
   /// a valid log.
@@ -187,7 +187,7 @@ class FilterEvent {
   /// For solidity events, the first topic is a hash of the event signature
   /// (except for anonymous events). All further topics are the encoded
   /// values of indexed parameters.
-  final List<String>? topics;
+  final List<String?>? topics;
 
   @override
   String toString() {


### PR DESCRIPTION
Maybe I'm misunderstanding how I should use this library feature. I need to be able to omit certain filters to filter any on the 2nd param and a specific item on the 3rd.

Therefore it would be better to have:

`final List<List<String?>>? topics;`

rather than:

`final List<List<String>>? topics;`

In order to achieve this type of filtering:

```
[
  "0x0000000000000000000000000000000000000000000000000000000000000000", 
  null, 
  "0x0000000000000000000000000000000000000000000000000000000000000000"
]
```