### PR TITLE
Feature Addition: EthrDID Constructors

### DIFF
--- a/lib/src/credentials/did.dart
+++ b/lib/src/credentials/did.dart
@@ -1,0 +1,38 @@
+import '../../credentials.dart';
+import '../../crypto.dart';
+
+class EthrDID {
+  const EthrDID(this.did);
+
+  factory EthrDID.fromPublicKeyEncoded({
+    required EthPrivateKey credentials,
+    required String chainNameOrId,
+  }) {
+    var did = 'did:ethr:$chainNameOrId:${bytesToHex(
+      credentials.publicKey.getEncoded(),
+      include0x: true,
+    )}';
+    return EthrDID(did);
+  }
+
+  factory EthrDID.fromEthereumAddress({
+    required EthereumAddress address,
+    required String chainNameOrId,
+  }) {
+    var did = 'did:ethr:$chainNameOrId:${address.hexEip55}';
+    return EthrDID(did);
+  }
+
+  /// `identifier` is Ethereum address, public key or a full did:ethr representing Identity
+  ///
+  /// https://github.com/uport-project/ethr-did#configuration
+  factory EthrDID.fromIdentifier({
+    required String identifier,
+    required String chainNameOrId,
+  }) {
+    var did = 'did:ethr:$chainNameOrId:$identifier';
+    return EthrDID(did);
+  }
+
+  final String did;
+}

--- a/test/credentials/ethr_did_test.dart
+++ b/test/credentials/ethr_did_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:web3dart/credentials.dart';
+import 'package:web3dart/crypto.dart';
+import 'package:web3dart/src/credentials/did.dart';
+
+void main() {
+  group('Generate ethr DID', () {
+    test('from Ethereum Address', () {
+      var address =
+          EthereumAddress.fromHex('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb');
+      var ethrDID =
+          EthrDID.fromEthereumAddress(address: address, chainNameOrId: '0x1');
+      expect(
+        ethrDID.did,
+        'did:ethr:0x1:0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+      );
+    });
+
+    test('from PublicKey Encoded', () {
+      final key = EthPrivateKey(
+        hexToBytes(
+          'a392604efc2fad9c0b3da43b5f698a2e3f270f170d859912be0d54742275c5f6',
+        ),
+      );
+      var ethrDID =
+          EthrDID.fromPublicKeyEncoded(credentials: key, chainNameOrId: '0x1');
+      expect(
+        bytesToHex(key.publicKey.getEncoded(), include0x: true),
+        '0x02506bc1dc099358e5137292f4efdd57e400f29ba5132aa5d12b18dac1c1f6aaba',
+      );
+      expect(
+        ethrDID.did,
+        'did:ethr:0x1:0x02506bc1dc099358e5137292f4efdd57e400f29ba5132aa5d12b18dac1c1f6aaba',
+      );
+    });
+
+    test('from Identifier', () {
+      var ethrDID = EthrDID.fromIdentifier(
+        identifier: 'web3dart',
+        chainNameOrId: 'goerli',
+      );
+      expect(
+        ethrDID.did,
+        'did:ethr:goerli:web3dart',
+      );
+    });
+  });
+}


### PR DESCRIPTION
**Description:**
This Pull Request introduces new features to the `EthrDID` class, enhancing its capabilities for creating Decentralized Identifiers (DIDs) for Ethereum-based identities (ref: https://github.com/uport-project/ethr-did). The changes include the addition of three new factory methods that allow the creation of `EthrDID` instances using different inputs:

1. **`fromPublicKeyEncoded`**: This factory method allows the creation of an `EthrDID` instance from an encoded public key. It takes an `EthPrivateKey` object and a `chainNameOrId` as input. The method constructs the DID by combining the chain name or ID with the hexadecimal representation of the provided encoded public key.

2. **`fromEthereumAddress`**: With this factory method, an `EthrDID` instance can be created directly from an Ethereum address. It takes an `EthereumAddress` object and a `chainNameOrId` as input. The method constructs the DID using the chain name or ID and the EIP-55 encoded representation of the Ethereum address.

3. **`fromIdentifier`**: This factory method offers flexibility by allowing the creation of an `EthrDID` instance from a custom identifier. It takes a `String` identifier and a `chainNameOrId` as input. The method constructs the DID using the provided identifier along with the chain name or ID. Examples of identifiers include Ethereum addresses, public keys, or even a full `did:ethr` representing Identity.

The new constructors provide more options for developers to create `EthrDID` instances based on their specific requirements, making the class more versatile and adaptable to different use cases.

Thank you for considering this Pull Request. I have tested the changes thoroughly to ensure their correctness and compatibility with existing code. Please review the changes, and I am open to any feedback or suggestions to improve the implementation further.

Let me know if you have any questions or need additional information.