### PR TITLE
Add EIP4844 support

### DIFF
--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -191,6 +191,16 @@ class Web3Client {
     ).then((json) => BlockInformation.fromJson(json));
   }
 
+  Future<Map<String,dynamic>> getBlockInformationRaw({
+    String blockNumber = 'latest',
+    bool isContainFullObj = true,
+  }) {
+    return makeRPCCall<Map<String, dynamic>>(
+      'eth_getBlockByNumber',
+      [blockNumber, isContainFullObj],
+    ).then((json) => json);
+  }
+
   /// Gets the balance of the account with the specified address.
   ///
   /// This function allows specifying a custom block mined in the past to get
@@ -341,8 +351,9 @@ class Web3Client {
 
     if (transaction.isEIP1559) {
       signed = prependTransactionType(0x02, signed);
+    } else if(transaction.isEIP4844){
+      signed = prependTransactionType(0x03, signed);
     }
-
     return sendRawTransaction(signed);
   }
 

--- a/lib/src/core/sidecar.dart
+++ b/lib/src/core/sidecar.dart
@@ -1,0 +1,13 @@
+part of 'package:web3dart/web3dart.dart';
+
+class Sidecar {
+  Sidecar({
+    required this.blobs,
+    required this.commitment,
+    required this.proof,
+  });
+
+  final List<Uint8List> blobs;
+  final List<Uint8List> commitment;
+  final List<Uint8List> proof;
+}

--- a/lib/src/credentials/credentials.dart
+++ b/lib/src/credentials/credentials.dart
@@ -77,6 +77,7 @@ abstract class Credentials {
     Uint8List payload, {
     int? chainId,
     bool isEIP1559 = false,
+    bool isEIP4844 = false,
   });
 
   /// Signs the [payload] with a private key and returns the obtained
@@ -85,6 +86,7 @@ abstract class Credentials {
     Uint8List payload, {
     int? chainId,
     bool isEIP1559 = false,
+    bool isEIP4844 = false,
   });
 
   /// Signs an Ethereum specific signature. This method is equivalent to
@@ -186,13 +188,14 @@ class EthPrivateKey extends CredentialsWithKnownAddress {
     Uint8List payload, {
     int? chainId,
     bool isEIP1559 = false,
+    bool isEIP4844 = false,
   }) async {
     final signature = secp256k1.sign(keccak256(payload), privateKey);
 
     // https://github.com/ethereumjs/ethereumjs-util/blob/8ffe697fafb33cefc7b7ec01c11e3a7da787fe0e/src/signature.ts#L26
     // be aware that signature.v already is recovery + 27
     int chainIdV;
-    if (isEIP1559) {
+    if (isEIP1559 || isEIP4844) {
       chainIdV = signature.v - 27;
     } else {
       chainIdV = chainId != null
@@ -207,13 +210,14 @@ class EthPrivateKey extends CredentialsWithKnownAddress {
     Uint8List payload, {
     int? chainId,
     bool isEIP1559 = false,
+    bool isEIP4844 = false,
   }) {
     final signature = secp256k1.sign(keccak256(payload), privateKey);
 
     // https://github.com/ethereumjs/ethereumjs-util/blob/8ffe697fafb33cefc7b7ec01c11e3a7da787fe0e/src/signature.ts#L26
     // be aware that signature.v already is recovery + 27
     int chainIdV;
-    if (isEIP1559) {
+    if (isEIP1559 || isEIP4844) {
       chainIdV = signature.v - 27;
     } else {
       chainIdV = chainId != null

--- a/lib/web3dart.dart
+++ b/lib/web3dart.dart
@@ -35,6 +35,7 @@ part 'src/core/block_information.dart';
 part 'src/core/client.dart';
 part 'src/core/filters.dart';
 part 'src/core/transaction.dart';
+part 'src/core/sidecar.dart';
 part 'src/core/transaction_information.dart';
 part 'src/core/transaction_signer.dart';
 part 'src/utils/length_tracking_byte_sink.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web3dart
 description: Dart library to connect to Ethereum clients. Send transactions and interact with smart contracts!
-version: 2.7.3-gate.1
+version: 2.7.3-gate+1
 homepage: https://pwa.ir
 repository: https://github.com/xclud/web3dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web3dart
 description: Dart library to connect to Ethereum clients. Send transactions and interact with smart contracts!
-version: 2.7.3
+version: 2.7.3-gate.1
 homepage: https://pwa.ir
 repository: https://github.com/xclud/web3dart
 


### PR DESCRIPTION
[refer from java version](https://github.com/hyperledger/web3j/blob/main/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java)

impl by dart and tested 
[transaction detail](https://sepolia.etherscan.io/tx/0x32c97fb86f781b4cde36c5d78c983d0697248bde2de4c35500e4de94c950e1b1
)


usage:


```dart
 final eip4844 = Transaction(
      to: address,
      maxFeePerGas: EtherAmount.fromBigInt(EtherUnit.wei,maxFeePerGas),
      maxPriorityFeePerGas:
          EtherAmount.fromBigInt(EtherUnit.wei, maxPriorityFeePerGasInt),
      maxGas: (gasLimit * BigInt.from(12) / BigInt.from(10)).toInt(),
      maxFeePerBlobGas: EtherAmount.fromBigInt(EtherUnit.wei, blobFeeCap),
      blobVersionedHashes: sidecar!.blobHashes(),
      nonce: nonce,
      value: EtherAmount.fromInt(EtherUnit.wei, 111),
      /// kzg from  https://github.com/weishirongzhen/dart_kzg_4844_util
      sidecar: Sidecar(
        blobs: sidecar!.blobs.map((e) => e.blob).toList(growable: false),
        commitment: sidecar!.commitments
            .map((e) => e.commitment)
            .toList(growable: false),
        proof: sidecar!.proofs.map((e) => e.proof).toList(growable: false),
      ),
    );
    final signedTx = await client.signTransaction(credentials, eip4844,
        chainId: chainId.toInt());
    result = await client.sendTransaction(
      credentials,
      eip4844,
      chainId: chainId.toInt(),
    );
```